### PR TITLE
Allow explicit toString/equals/hashCode

### DIFF
--- a/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/DataApiCodegenExtension.kt
+++ b/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/DataApiCodegenExtension.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.common.messages.MessageUtil
 import org.jetbrains.kotlin.codegen.ImplementationBodyCodegen
 import org.jetbrains.kotlin.codegen.extensions.ExpressionCodegenExtension
+import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
@@ -46,41 +47,44 @@ class DataApiCodegenExtension(
             codegen.bindingContext.get(BindingContext.VALUE_PARAMETER_AS_PROPERTY, parameter)
         }
 
-        ToStringGenerator(
-            declaration = codegen.myClass as KtClassOrObject,
-            classDescriptor = targetClass,
-            classAsmType = codegen.typeMapper.mapType(targetClass),
-            fieldOwnerContext = codegen.context,
-            v = codegen.v,
-            generationState = codegen.state
-        ).generate(
-            targetClass.findFunction("toString")!!,
-            properties
-        )
+        val toStringFunction = targetClass.findFunction("toString")!!
+        // Only generate if it's a fake override (of Any.toString):
+        if (toStringFunction.kind == CallableMemberDescriptor.Kind.FAKE_OVERRIDE) {
+            ToStringGenerator(
+                declaration = codegen.myClass as KtClassOrObject,
+                classDescriptor = targetClass,
+                classAsmType = codegen.typeMapper.mapType(targetClass),
+                fieldOwnerContext = codegen.context,
+                v = codegen.v,
+                generationState = codegen.state
+            ).generate(toStringFunction, properties)
+        }
 
-        EqualsGenerator(
-            declaration = codegen.myClass as KtClassOrObject,
-            classDescriptor = targetClass,
-            classAsmType = codegen.typeMapper.mapType(targetClass),
-            fieldOwnerContext = codegen.context,
-            v = codegen.v,
-            generationState = codegen.state
-        ).generate(
-            targetClass.findFunction("equals")!!,
-            properties
-        )
+        val equalsFunction = targetClass.findFunction("equals")!!
+        // Only generate if it's a fake override (of Any.equals):
+        if (equalsFunction.kind == CallableMemberDescriptor.Kind.FAKE_OVERRIDE) {
+            EqualsGenerator(
+                declaration = codegen.myClass as KtClassOrObject,
+                classDescriptor = targetClass,
+                classAsmType = codegen.typeMapper.mapType(targetClass),
+                fieldOwnerContext = codegen.context,
+                v = codegen.v,
+                generationState = codegen.state
+            ).generate(equalsFunction, properties)
+        }
 
-        HashCodeGenerator(
-            declaration = codegen.myClass as KtClassOrObject,
-            classDescriptor = targetClass,
-            classAsmType = codegen.typeMapper.mapType(targetClass),
-            fieldOwnerContext = codegen.context,
-            v = codegen.v,
-            generationState = codegen.state
-        ).generate(
-            targetClass.findFunction("hashCode")!!,
-            properties
-        )
+        val hashCodeFunction = targetClass.findFunction("hashCode")!!
+        // Only generate if it's a fake override (of Any.hashCode):
+        if (hashCodeFunction.kind == CallableMemberDescriptor.Kind.FAKE_OVERRIDE) {
+            HashCodeGenerator(
+                declaration = codegen.myClass as KtClassOrObject,
+                classDescriptor = targetClass,
+                classAsmType = codegen.typeMapper.mapType(targetClass),
+                fieldOwnerContext = codegen.context,
+                v = codegen.v,
+                generationState = codegen.state
+            ).generate(hashCodeFunction, properties)
+        }
 
         // TODO("Generate Builder")
         // TODO("Generate top-level DSL constructor")

--- a/extracare-compiler-plugin/src/test/kotlin/dev/drewhamilton/extracare/ExtraCarePluginTest.kt
+++ b/extracare-compiler-plugin/src/test/kotlin/dev/drewhamilton/extracare/ExtraCarePluginTest.kt
@@ -46,6 +46,24 @@ class ExtraCarePluginTest {
         assertThat(result.messages).contains("@DataApi classes must have a primary constructor")
     }
 
+    @Test fun `compilation with explicit function declarations succeeds`() {
+        val classWithExplicitFunctionDeclarations = """
+            package dev.drewhamilton.extracare
+
+            import dev.drewhamilton.extracare.DataApi
+
+            @DataApi class ExplicitDeclarationsClass(private val string: String) {
+                override fun toString() = string
+                override fun equals(other: Any?) = other == string
+                override fun hashCode() = string.hashCode()
+            }
+        """.trimIndent()
+        val classFile = SourceFile.kotlin("ExplicitFunctionDeclarationClass.kt", classWithExplicitFunctionDeclarations)
+        val result = prepareCompilation(classFile).compile()
+
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+
     private fun prepareCompilation(vararg sourceFiles: SourceFile) = KotlinCompilation().apply {
         workingDir = temporaryFolder.root
         compilerPlugins = listOf<ComponentRegistrar>(ExtraCareComponentRegistrar())

--- a/sample/src/main/kotlin/dev/drewhamilton/extracare/sample/explicit/ChildOfExplicitFunctionDeclarations.kt
+++ b/sample/src/main/kotlin/dev/drewhamilton/extracare/sample/explicit/ChildOfExplicitFunctionDeclarations.kt
@@ -1,0 +1,7 @@
+package dev.drewhamilton.extracare.sample.explicit
+
+import dev.drewhamilton.extracare.DataApi
+
+@DataApi class ChildOfExplicitFunctionDeclarations(
+    private val string: String
+) : SuperExplicitFunctionDeclarations(string)

--- a/sample/src/main/kotlin/dev/drewhamilton/extracare/sample/explicit/ExplicitFunctionDeclarations.kt
+++ b/sample/src/main/kotlin/dev/drewhamilton/extracare/sample/explicit/ExplicitFunctionDeclarations.kt
@@ -1,0 +1,11 @@
+package dev.drewhamilton.extracare.sample.explicit
+
+import dev.drewhamilton.extracare.DataApi
+
+@DataApi class ExplicitFunctionDeclarations(
+    private val string: String
+) {
+    override fun toString() = string
+    override fun equals(other: Any?) = other == true
+    override fun hashCode() = string.hashCode()
+}

--- a/sample/src/main/kotlin/dev/drewhamilton/extracare/sample/explicit/SuperExplicitFunctionDeclarations.kt
+++ b/sample/src/main/kotlin/dev/drewhamilton/extracare/sample/explicit/SuperExplicitFunctionDeclarations.kt
@@ -1,0 +1,9 @@
+package dev.drewhamilton.extracare.sample.explicit
+
+open class SuperExplicitFunctionDeclarations(
+    private val string: String
+) {
+    override fun toString() = string
+    override fun equals(other: Any?) = other == true
+    override fun hashCode() = string.hashCode()
+}

--- a/sample/src/test/kotlin/dev/drewhamilton/extracare/sample/explicit/ChildOfExplicitFunctionDeclarationsTest.kt
+++ b/sample/src/test/kotlin/dev/drewhamilton/extracare/sample/explicit/ChildOfExplicitFunctionDeclarationsTest.kt
@@ -1,0 +1,16 @@
+package dev.drewhamilton.extracare.sample.explicit
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ChildOfExplicitFunctionDeclarationsTest {
+
+    private val childOfExplicitFunctionDeclarations = ChildOfExplicitFunctionDeclarations("test")
+
+    @Test fun `ExplicitFunctionDeclarations overrides explicit function declarations`() {
+        assertThat(childOfExplicitFunctionDeclarations.toString()).isEqualTo("test")
+        assertThat(childOfExplicitFunctionDeclarations).isEqualTo(true)
+        assertThat(childOfExplicitFunctionDeclarations).isNotEqualTo(false)
+        assertThat(childOfExplicitFunctionDeclarations.hashCode()).isEqualTo("test".hashCode())
+    }
+}

--- a/sample/src/test/kotlin/dev/drewhamilton/extracare/sample/explicit/ChildOfExplicitFunctionDeclarationsTest.kt
+++ b/sample/src/test/kotlin/dev/drewhamilton/extracare/sample/explicit/ChildOfExplicitFunctionDeclarationsTest.kt
@@ -2,15 +2,18 @@ package dev.drewhamilton.extracare.sample.explicit
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import java.util.Objects
 
 class ChildOfExplicitFunctionDeclarationsTest {
 
     private val childOfExplicitFunctionDeclarations = ChildOfExplicitFunctionDeclarations("test")
 
     @Test fun `ExplicitFunctionDeclarations overrides explicit function declarations`() {
-        assertThat(childOfExplicitFunctionDeclarations.toString()).isEqualTo("test")
-        assertThat(childOfExplicitFunctionDeclarations).isEqualTo(true)
+        assertThat(childOfExplicitFunctionDeclarations.toString())
+            .isEqualTo("ChildOfExplicitFunctionDeclarations(string=test)")
+        assertThat(childOfExplicitFunctionDeclarations).isNotEqualTo(true)
         assertThat(childOfExplicitFunctionDeclarations).isNotEqualTo(false)
-        assertThat(childOfExplicitFunctionDeclarations.hashCode()).isEqualTo("test".hashCode())
+        assertThat(childOfExplicitFunctionDeclarations).isEqualTo(ChildOfExplicitFunctionDeclarations("test"))
+        assertThat(childOfExplicitFunctionDeclarations.hashCode()).isEqualTo(Objects.hash("test") - 31)
     }
 }

--- a/sample/src/test/kotlin/dev/drewhamilton/extracare/sample/explicit/DataChildOfExplicitFunctionDeclarations.kt
+++ b/sample/src/test/kotlin/dev/drewhamilton/extracare/sample/explicit/DataChildOfExplicitFunctionDeclarations.kt
@@ -1,0 +1,6 @@
+package dev.drewhamilton.extracare.sample.explicit
+
+@Suppress("unused") // Useful reference
+data class DataChildOfExplicitFunctionDeclarations(
+    private val string: String
+) : SuperExplicitFunctionDeclarations(string)

--- a/sample/src/test/kotlin/dev/drewhamilton/extracare/sample/explicit/ExplicitFunctionDeclarationsTest.kt
+++ b/sample/src/test/kotlin/dev/drewhamilton/extracare/sample/explicit/ExplicitFunctionDeclarationsTest.kt
@@ -1,0 +1,16 @@
+package dev.drewhamilton.extracare.sample.explicit
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ExplicitFunctionDeclarationsTest {
+
+    private val explicitFunctionDeclarations = ExplicitFunctionDeclarations("test")
+
+    @Test fun `ExplicitFunctionDeclarations honors explicit function declarations`() {
+        assertThat(explicitFunctionDeclarations.toString()).isEqualTo("test")
+        assertThat(explicitFunctionDeclarations).isEqualTo(true)
+        assertThat(explicitFunctionDeclarations).isNotEqualTo(false)
+        assertThat(explicitFunctionDeclarations.hashCode()).isEqualTo("test".hashCode())
+    }
+}


### PR DESCRIPTION
Fixes #11.

Behaves like data classes: Does not generate these functions if and only if they are explicitly declared directly in the `@DataApi` class. Overrides any explicit declarations in parent classes.