### PR TITLE
Binary compatibility validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,14 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
+        classpath "org.jetbrains.kotlinx:binary-compatibility-validator:$binary_compatibility_validator_version"
         classpath "$publish_group:$publish_gradle_plugin_artifact"
     }
+}
+
+apply plugin: 'binary-compatibility-validator'
+apiValidation {
+    ignoredProjects += ['sample']
 }
 
 String resolvedJvmTarget = System.getenv().getOrDefault('ci_java_version', JavaVersion.VERSION_1_8.toString())

--- a/data-api-annotations/api/data-api-annotations.api
+++ b/data-api-annotations/api/data-api-annotations.api
@@ -1,0 +1,3 @@
+public abstract interface annotation class dev/drewhamilton/extracare/DataApi : java/lang/annotation/Annotation {
+}
+

--- a/extracare-compiler-plugin/api/extracare-compiler-plugin.api
+++ b/extracare-compiler-plugin/api/extracare-compiler-plugin.api
@@ -1,0 +1,16 @@
+public final class dev/drewhamilton/extracare/ExtraCareCommandLineProcessor : org/jetbrains/kotlin/compiler/plugin/CommandLineProcessor {
+	public fun <init> ()V
+	public fun appendList (Lorg/jetbrains/kotlin/config/CompilerConfiguration;Lorg/jetbrains/kotlin/config/CompilerConfigurationKey;Ljava/lang/Object;)V
+	public fun appendList (Lorg/jetbrains/kotlin/config/CompilerConfiguration;Lorg/jetbrains/kotlin/config/CompilerConfigurationKey;Ljava/util/List;)V
+	public fun applyOptionsFrom (Lorg/jetbrains/kotlin/config/CompilerConfiguration;Ljava/util/Map;Ljava/util/Collection;)V
+	public fun getPluginId ()Ljava/lang/String;
+	public fun getPluginOptions ()Ljava/util/Collection;
+	public fun processOption (Lorg/jetbrains/kotlin/compiler/plugin/AbstractCliOption;Ljava/lang/String;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
+	public fun processOption (Lorg/jetbrains/kotlin/compiler/plugin/CliOption;Ljava/lang/String;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
+}
+
+public final class dev/drewhamilton/extracare/ExtraCareComponentRegistrar : org/jetbrains/kotlin/compiler/plugin/ComponentRegistrar {
+	public fun <init> ()V
+	public fun registerProjectComponents (Lorg/jetbrains/kotlin/com/intellij/mock/MockProject;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
+}
+

--- a/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/CompilerOptions.kt
+++ b/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/CompilerOptions.kt
@@ -1,0 +1,7 @@
+package dev.drewhamilton.extracare
+
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
+
+internal object CompilerOptions {
+    val ENABLED = CompilerConfigurationKey<Boolean>("enabled")
+}

--- a/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/ExtraCareCommandLineProcessor.kt
+++ b/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/ExtraCareCommandLineProcessor.kt
@@ -5,7 +5,6 @@ import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.CompilerConfigurationKey
 
 @AutoService(CommandLineProcessor::class)
 class ExtraCareCommandLineProcessor : CommandLineProcessor {
@@ -14,7 +13,7 @@ class ExtraCareCommandLineProcessor : CommandLineProcessor {
     override val pluginId = "extracare-compiler-plugin"
 
     override val pluginOptions: Collection<AbstractCliOption> = listOf(
-        CliOption(Options.ENABLED, "<true|false>", "", required = true)
+        CliOption(CompilerOptions.ENABLED.toString(), "<true|false>", "", required = true)
     )
 
     override fun processOption(
@@ -22,15 +21,7 @@ class ExtraCareCommandLineProcessor : CommandLineProcessor {
         value: String,
         configuration: CompilerConfiguration
     ) = when (option.optionName) {
-        Options.ENABLED -> configuration.put(KEY_ENABLED, value.toBoolean())
+        CompilerOptions.ENABLED.toString() -> configuration.put(CompilerOptions.ENABLED, value.toBoolean())
         else -> throw IllegalArgumentException("Unknown plugin option: ${option.optionName}")
-    }
-
-    private object Options {
-        const val ENABLED = "enabled"
-    }
-
-    internal companion object {
-        internal val KEY_ENABLED = CompilerConfigurationKey<Boolean>(Options.ENABLED)
     }
 }

--- a/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/ExtraCareComponentRegistrar.kt
+++ b/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/ExtraCareComponentRegistrar.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.extensions.ProjectExtensionDescriptor
 class ExtraCareComponentRegistrar : ComponentRegistrar {
 
     override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {
-        if (configuration[ExtraCareCommandLineProcessor.KEY_ENABLED] == false)
+        if (configuration[CompilerOptions.ENABLED] == false)
             return
 
         // TODO: Use ClassBuilderInterceptorExtension, ExpressionCodegenExtension, or both?

--- a/extracare-gradle-plugin/api/extracare-gradle-plugin.api
+++ b/extracare-gradle-plugin/api/extracare-gradle-plugin.api
@@ -1,0 +1,17 @@
+public final class dev/drewhamilton/extracare/gradle/ExtraCareGradlePlugin : org/jetbrains/kotlin/gradle/plugin/KotlinCompilerPluginSupportPlugin {
+	public fun <init> ()V
+	public synthetic fun apply (Ljava/lang/Object;)V
+	public fun apply (Lorg/gradle/api/Project;)V
+	public fun applyToCompilation (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Lorg/gradle/api/provider/Provider;
+	public fun getCompilerPluginId ()Ljava/lang/String;
+	public fun getPluginArtifact ()Lorg/jetbrains/kotlin/gradle/plugin/SubpluginArtifact;
+	public fun getPluginArtifactForNative ()Lorg/jetbrains/kotlin/gradle/plugin/SubpluginArtifact;
+	public fun isApplicable (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Z
+}
+
+public abstract class dev/drewhamilton/extracare/gradle/ExtraCarePluginExtension {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getEnabled ()Lorg/gradle/api/provider/Property;
+	public final fun setEnabled (Lorg/gradle/api/provider/Property;)V
+}
+

--- a/extracare-gradle-plugin/build.gradle
+++ b/extracare-gradle-plugin/build.gradle
@@ -20,13 +20,15 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlinx:binary-compatibility-validator:$binary_compatibility_validator_version"
     }
 }
 
-apply plugin: "java-gradle-plugin"
-apply plugin: "org.jetbrains.kotlin.jvm"
-apply plugin: "org.jetbrains.kotlin.kapt"
+apply plugin: 'java-gradle-plugin'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'org.jetbrains.kotlin.kapt'
 apply plugin: 'org.jetbrains.dokka'
+apply plugin: 'binary-compatibility-validator'
 
 ext {
     artifactName = publish_gradle_plugin_artifact

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ kotlin.code.style=official
 kotlin_version=1.4.21
 autoservice_version=1.0-rc7
 dokka_version=1.4.20
+binary_compatibility_validator_version=0.3.0
 
 #region Artifact info
 publish_group=dev.drewhamilton.extracare

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,6 +3,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'dev.drewhamilton.extracare'
 
+extraCare {
+    enabled.set true
+}
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 


### PR DESCRIPTION
Add Kotlin's binary compatibility validator to be aware of breaking changes going forward. Make minor refactors to minimize public API.