### PR TITLE
Support custom annotations

### DIFF
--- a/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/Annotation.kt
+++ b/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/Annotation.kt
@@ -1,5 +1,0 @@
-package dev.drewhamilton.extracare
-
-import org.jetbrains.kotlin.name.FqName
-
-internal val dataApiAnnotationName = FqName("dev.drewhamilton.extracare.DataApi")

--- a/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/CompilerOptions.kt
+++ b/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/CompilerOptions.kt
@@ -4,4 +4,5 @@ import org.jetbrains.kotlin.config.CompilerConfigurationKey
 
 internal object CompilerOptions {
     val ENABLED = CompilerConfigurationKey<Boolean>("enabled")
+    val DATA_API_ANNOTATION = CompilerConfigurationKey<String>("dataApiAnnotation")
 }

--- a/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/ExtraCareCommandLineProcessor.kt
+++ b/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/ExtraCareCommandLineProcessor.kt
@@ -13,7 +13,8 @@ class ExtraCareCommandLineProcessor : CommandLineProcessor {
     override val pluginId = "extracare-compiler-plugin"
 
     override val pluginOptions: Collection<AbstractCliOption> = listOf(
-        CliOption(CompilerOptions.ENABLED.toString(), "<true|false>", "", required = true)
+        CliOption(CompilerOptions.ENABLED.toString(), "<true|false>", "", required = true),
+        CliOption(CompilerOptions.DATA_API_ANNOTATION.toString(), "Annotation class name", "", required = true),
     )
 
     override fun processOption(
@@ -22,6 +23,7 @@ class ExtraCareCommandLineProcessor : CommandLineProcessor {
         configuration: CompilerConfiguration
     ) = when (option.optionName) {
         CompilerOptions.ENABLED.toString() -> configuration.put(CompilerOptions.ENABLED, value.toBoolean())
+        CompilerOptions.DATA_API_ANNOTATION.toString() -> configuration.put(CompilerOptions.DATA_API_ANNOTATION, value)
         else -> throw IllegalArgumentException("Unknown plugin option: ${option.optionName}")
     }
 }

--- a/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/codegen/DataApiCodegenExtension.kt
+++ b/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/codegen/DataApiCodegenExtension.kt
@@ -1,6 +1,5 @@
 package dev.drewhamilton.extracare.codegen
 
-import dev.drewhamilton.extracare.dataApiAnnotationName
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
@@ -13,12 +12,14 @@ import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
 import org.jetbrains.kotlin.descriptors.annotations.Annotated
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.source.getPsi
 
 internal class DataApiCodegenExtension(
+    private val dataApiAnnotationName: FqName,
     private val messageCollector: MessageCollector
 ) : ExpressionCodegenExtension {
 

--- a/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/ir/DataApiIrGenerationExtension.kt
+++ b/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/ir/DataApiIrGenerationExtension.kt
@@ -2,15 +2,36 @@ package dev.drewhamilton.extracare.ir
 
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.common.messages.MessageUtil
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
+import org.jetbrains.kotlin.name.FqName
 
 internal class DataApiIrGenerationExtension(
+    private val dataApiAnnotationName: FqName,
     private val messageCollector: MessageCollector
 ) : IrGenerationExtension {
 
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
-        val dataApiMembersTransformer = DataApiMembersTransformer(pluginContext, messageCollector)
+        val dataApiAnnotationClass = pluginContext.referenceClass(dataApiAnnotationName)
+        if (dataApiAnnotationClass == null) {
+            moduleFragment.reportError("Could not find class <$dataApiAnnotationName>")
+            return
+        }
+
+        val dataApiMembersTransformer = DataApiMembersTransformer(
+            dataApiAnnotationClass,
+            pluginContext,
+            messageCollector
+        )
         moduleFragment.transform(dataApiMembersTransformer, null)
+    }
+
+    private fun IrModuleFragment.reportError(message: String) {
+        val psi = descriptor.findPsi()
+        val location = MessageUtil.psiElementToMessageLocation(psi)
+        messageCollector.report(CompilerMessageSeverity.ERROR, message, location)
     }
 }

--- a/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/ir/DataApiMembersTransformer.kt
+++ b/extracare-compiler-plugin/src/main/kotlin/dev/drewhamilton/extracare/ir/DataApiMembersTransformer.kt
@@ -1,6 +1,5 @@
 package dev.drewhamilton.extracare.ir
 
-import dev.drewhamilton.extracare.dataApiAnnotationName
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
@@ -67,11 +66,10 @@ import org.jetbrains.kotlin.types.typeUtil.representativeUpperBound
 
 @OptIn(ObsoleteDescriptorBasedAPI::class)
 internal class DataApiMembersTransformer(
+    private val annotationClass: IrClassSymbol,
     private val pluginContext: IrPluginContext,
     private val messageCollector: MessageCollector,
 ) : IrElementTransformerVoidWithContext() {
-
-    private val annotationClass: IrClassSymbol = pluginContext.referenceClass(dataApiAnnotationName)!!
 
     override fun visitFunctionNew(declaration: IrFunction): IrStatement {
         log("Reading <$declaration>")

--- a/extracare-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/extracare-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/extracare-gradle-plugin/src/main/kotlin/dev/drewhamilton/extracare/gradle/ExtraCareGradlePlugin.kt
+++ b/extracare-gradle-plugin/src/main/kotlin/dev/drewhamilton/extracare/gradle/ExtraCareGradlePlugin.kt
@@ -9,7 +9,6 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
-@Suppress("unused") // Referenced in extracare-gradle-plugin/build.gradle
 class ExtraCareGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
     override fun apply(target: Project) {
@@ -34,16 +33,23 @@ class ExtraCareGradlePlugin : KotlinCompilerPluginSupportPlugin {
         val project = kotlinCompilation.target.project
         val extension = project.extensions.getByType(ExtraCarePluginExtension::class.java)
 
-        // Add annotations as a dependency
-        project.dependencies.add(
-            "implementation",
-            "${ArtifactInfo.GROUP}:${ArtifactInfo.ANNOTATIONS_ARTIFACT}:${ArtifactInfo.VERSION}"
-        )
+        if (extension.dataApiAnnotation.get() == DEFAULT_DATA_API_ANNOTATION) {
+            // Add default annotation as a dependency
+            project.dependencies.add(
+                "implementation",
+                "${ArtifactInfo.GROUP}:${ArtifactInfo.ANNOTATIONS_ARTIFACT}:${ArtifactInfo.VERSION}"
+            )
+        }
 
         return project.provider {
             listOf(
-                SubpluginOption(key = "enabled", value = extension.enabled.get().toString())
+                SubpluginOption(key = "enabled", value = extension.enabled.get().toString()),
+                SubpluginOption(key = "dataApiAnnotation", value = extension.dataApiAnnotation.get().toString()),
             )
         }
+    }
+
+    internal companion object {
+        internal const val DEFAULT_DATA_API_ANNOTATION = "dev.drewhamilton.extracare.DataApi"
     }
 }

--- a/extracare-gradle-plugin/src/main/kotlin/dev/drewhamilton/extracare/gradle/ExtraCarePluginExtension.kt
+++ b/extracare-gradle-plugin/src/main/kotlin/dev/drewhamilton/extracare/gradle/ExtraCarePluginExtension.kt
@@ -4,9 +4,11 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import javax.inject.Inject
 
-abstract class ExtraCarePluginExtension @Inject constructor(
-    objects: ObjectFactory
-) {
-    var enabled: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
+abstract class ExtraCarePluginExtension @Inject constructor(objects: ObjectFactory) {
+
+    val enabled: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
         .convention(true)
+
+    val dataApiAnnotation: Property<String> = objects.property(String::class.java)
+        .convention(ExtraCareGradlePlugin.DEFAULT_DATA_API_ANNOTATION)
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'dev.drewhamilton.extracare'
 
 extraCare {
+    dataApiAnnotation.set 'dev.drewhamilton.extracare.sample.Poko'
     enabled.set true
 }
 

--- a/sample/src/main/kotlin/dev/drewhamilton/extracare/sample/Poko.kt
+++ b/sample/src/main/kotlin/dev/drewhamilton/extracare/sample/Poko.kt
@@ -1,0 +1,9 @@
+package dev.drewhamilton.extracare.sample
+
+/**
+ * Annotation used for Extra Care compiler plugin, which generates [equals], [hashCode], and [toString] for the
+ * annotated class.
+ */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS)
+annotation class Poko

--- a/sample/src/main/kotlin/dev/drewhamilton/extracare/sample/Sample.kt
+++ b/sample/src/main/kotlin/dev/drewhamilton/extracare/sample/Sample.kt
@@ -1,9 +1,7 @@
 package dev.drewhamilton.extracare.sample
 
-import dev.drewhamilton.extracare.DataApi
-
 @Suppress("unused")
-@DataApi class Sample(
+@Poko class Sample(
     val int: Int,
     val requiredString: String,
     val optionalString: String?


### PR DESCRIPTION
Closes #29.

In the `extraCare` configuration block, consumers can set whatever class they choose as the data API annotation:
```groovy
extraCare {
    dataApiAnnotation.set 'com.example.GeneratedEqualsAndToString'
}
```
```kotlin
@GeneratedEqualsAndToString class DataModel(val id: String)
```